### PR TITLE
Update handlebars dependencies so server compiler version matches client version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,8 @@
     "mocha": "~1.9.0",
     "jquery": "~1.9.1",
     "expect": "~0.2.0",
-    "ember": "~1.0.0-rc.2",
+    "ember": "1.0.0-rc.4",
+    "handlebars": "1.0.0-rc.4",
     "bootstrap": "~2.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "grunt-regarde": "~0.1.1",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-open": "~0.2.0",
-    "grunt-ember-templates": "~0.4.4",
+    "grunt-ember-templates": "~0.4.7",
     "grunt-stitch-extra": "~0.4.3",
     "mocha-phantomjs": "~2.0.1"
   }


### PR DESCRIPTION
- ember-templates is compiling handlebars using compiler version 3
  which is incompatible with the version of handlebars being downloaded
  by bower. So, the app doesn't work on boot. Set handlebars/ember client
  side dependencies to rc4 until ember-templates is updated
